### PR TITLE
Simplify auth flow and silence unauthenticated noise

### DIFF
--- a/frontend/src/Components/Header.tsx
+++ b/frontend/src/Components/Header.tsx
@@ -1,13 +1,18 @@
-import { useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { LuSquareMenu } from "react-icons/lu";
-import { useAuth } from "../hooks/useAuth";
+import { AuthContext } from "../contexts/AuthContext";
 
 export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  const { user, logout } = useAuth();
+  const auth = useContext(AuthContext);
+  if (!auth) {
+    throw new Error("Header must be used within an AuthProvider");
+  }
+
+  const { user, logout } = auth;
 
   //detect outer area of menu
   useEffect(() => {
@@ -63,7 +68,7 @@ export const Header = () => {
                 {user ? (
                   <button
                     onClick={() => {
-                      logout();
+                      void logout();
                       setIsMenuOpen(false);
                     }}
                   >

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,9 +1,0 @@
-// src/hooks/useAuth.ts
-import { useContext } from "react";
-import { AuthContext } from "../contexts/AuthContext";
-
-export const useAuth = () => {
-  const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
-  return ctx;
-};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,13 +4,4 @@ import react from "@vitejs/plugin-react-swc";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  server: {
-    proxy: {
-      "/api": {
-        target: "http://localhost:3000",
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, "/api"),
-      },
-    },
-  },
 });

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -133,7 +133,7 @@ router.post("/login", async (req: Request, res: Response) => {
     //set cookie
     res.cookie("session_id", sessionId, {
       httpOnly: true,
-      secure: true,
+      secure: process.env.NODE_ENV === "production",
       sameSite: "strict",
       expires: expiresAt,
     });
@@ -180,7 +180,7 @@ router.post("/logout", async (req: Request, res: Response) => {
 
     res.clearCookie("session_id", {
       httpOnly: true,
-      secure: true,
+      secure: process.env.NODE_ENV === "production",
       sameSite: "strict",
     });
 
@@ -201,7 +201,7 @@ router.get("/status", async (req: Request, res: Response) => {
   const sessionIdRaw = req.cookies?.session_id;
 
   if (!sessionIdRaw) {
-    return res.status(401).json({
+    return res.json({
       success: false,
       error: "not logged in",
     } satisfies ApiResponse<null>);
@@ -227,7 +227,7 @@ router.get("/status", async (req: Request, res: Response) => {
     const session = rows[0];
 
     if (!session || session.expires_at < new Date()) {
-      return res.status(401).json({
+      return res.json({
         success: false,
         error: "session expired or invalid",
       } satisfies ApiResponse<null>);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3,6 +3,10 @@ import cors from "cors";
 import dotenv from "dotenv";
 import path from "path";
 import cookieParser from "cookie-parser";
+import { createRequire } from "module";
+
+import postsRouter from "@/routes/posts";
+import authRouter from "@/routes/auth";
 
 dotenv.config();
 
@@ -10,36 +14,73 @@ const envFile =
   process.env.NODE_ENV === "production" ? ".env.prod" : ".env.dev";
 dotenv.config({ path: path.resolve(__dirname, "..", envFile) });
 
-const app = express();
-
-if (process.env.NODE_ENV === "production") {
-  app.set("trust proxy", 1); // 🔐 secure cookies 허용 (e.g. Heroku, nginx behind)
-}
-
-app.use(express.json());
-app.use(cookieParser());
-
 const PORT = process.env.PORT || 3000;
 
-const corsOrigin = process.env.CORS_ORIGIN || "";
+const startServer = async () => {
+  const app = express();
 
-app.use(
-  cors({
-    origin: corsOrigin,
-    credentials: true,
-  })
-);
+  const isProduction = process.env.NODE_ENV === "production";
+  const distPath = path.resolve(__dirname, "..", "..", "frontend", "dist");
 
-app.use(express.json());
+  if (isProduction) {
+    app.set("trust proxy", 1); // 🔐 secure cookies 허용 (e.g. Heroku, nginx behind)
+    app.use(express.static(distPath));
+  } else {
+    try {
+      const frontendRequire = createRequire(
+        path.resolve(__dirname, "..", "..", "frontend", "package.json")
+      );
+      const viteEntry = frontendRequire.resolve("vite");
+      const { createServer: createViteServer } = await import(viteEntry);
+      const vite = await createViteServer({
+        root: path.resolve(__dirname, "..", "..", "frontend"),
+        server: {
+          middlewareMode: true,
+        },
+        appType: "custom",
+      });
+      app.use(vite.middlewares);
+    } catch (error) {
+      console.error(
+        "Failed to start Vite in middleware mode. Make sure frontend dependencies are installed.",
+        error
+      );
+      throw error;
+    }
+  }
 
-import postsRouter from "@/routes/posts";
-app.use("/api/posts", postsRouter);
+  app.use(express.json());
+  app.use(cookieParser());
 
-import authRouter from "@/routes/auth";
-app.use("/api/auth", authRouter);
+  const corsOrigin = process.env.CORS_ORIGIN;
 
-//404?
+  app.use(
+    cors({
+      origin: corsOrigin || undefined,
+      credentials: true,
+    })
+  );
 
-app.listen(PORT, () => {
-  console.log(`🚀 서버가 http://localhost:${PORT} 에서 실행 중입니다.`);
+  app.use("/api/posts", postsRouter);
+
+  app.use("/api/auth", authRouter);
+
+  if (isProduction) {
+    const indexHtmlPath = path.join(distPath, "index.html");
+    app.get("*", (req, res, next) => {
+      if (req.path.startsWith("/api")) {
+        return next();
+      }
+      res.sendFile(indexHtmlPath);
+    });
+  }
+
+  app.listen(PORT, () => {
+    console.log(`🚀 서버가 http://localhost:${PORT} 에서 실행 중입니다.`);
+  });
+};
+
+startServer().catch((error) => {
+  console.error("Failed to start server", error);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- fold login/logout helpers into the AuthContext, expose refresh/login methods, and drop the thin useAuth hook
- update the header and login screen to use the new context API, including submit guards and messaging
- return 200 responses for unauthenticated status checks and only set secure cookies in production

## Testing
- npm run build:server
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_69096482f1f88330aa199d6d04f514b4